### PR TITLE
Add compare_relation_columns macro

### DIFF
--- a/integration_tests/analysis/compare_relation_columns_smoke_test.sql
+++ b/integration_tests/analysis/compare_relation_columns_smoke_test.sql
@@ -1,0 +1,15 @@
+{% set a_relation=ref('data_compare_relations__a_relation') %}
+
+{% set compare_relation_columns_sql = audit_helper.compare_relation_columns(
+    a_relation,
+    a_relation
+) %}
+
+{{ compare_relation_columns_sql }}
+
+{% if execute %}
+
+{% set results = run_query(compare_relation_columns_sql) %}
+{% do results.print_table()  %}
+
+{% endif %}

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 
-name: 'adit_helper_integration_tests'
+name: 'audit_helper_integration_tests'
 version: '1.0'
 
 profile: 'audit_helper_integration_tests'

--- a/macros/compare_relation_columns.sql
+++ b/macros/compare_relation_columns.sql
@@ -1,0 +1,160 @@
+{% macro compare_relation_columns(a_relation, b_relation) %}
+with a_cols as (
+    {{ audit_helper.get_columns_in_relation_sql(a_relation) }}
+),
+
+b_cols as (
+    {{ audit_helper.get_columns_in_relation_sql(b_relation) }}
+)
+
+select
+    column_name,
+    a_cols.ordinal_position as a_ordinal_position,
+    b_cols.ordinal_position as b_ordinal_position,
+    a_cols.data_type as a_data_type,
+    b_cols.data_type as b_data_type
+from a_cols
+full outer join b_cols using (column_name)
+order by a_ordinal_position, b_ordinal_position
+
+{% endmacro %}
+
+
+{% macro get_columns_in_relation_sql(relation) %}
+
+{{ adapter_macro('audit_helper.get_columns_in_relation_sql', relation) }}
+
+{% endmacro %}
+
+{% macro redshift__get_columns_in_relation_sql(relation) %}
+{#-
+See https://github.com/fishtown-analytics/dbt/blob/23484b18b71010f701b5312f920f04529ceaa6b2/plugins/redshift/dbt/include/redshift/macros/adapters.sql#L71
+Edited to include ordinal_position
+-#}
+with bound_views as (
+  select
+    ordinal_position,
+    table_schema,
+    column_name,
+    data_type,
+    character_maximum_length,
+    numeric_precision,
+    numeric_scale
+
+  from information_schema."columns"
+  where table_name = '{{ relation.identifier }}'
+),
+
+unbound_views as (
+select
+  ordinal_position,
+  view_schema,
+  col_name,
+  case
+    when col_type ilike 'character varying%' then
+      'character varying'
+    when col_type ilike 'numeric%' then 'numeric'
+    else col_type
+  end as col_type,
+  case
+    when col_type like 'character%'
+    then nullif(REGEXP_SUBSTR(col_type, '[0-9]+'), '')::int
+    else null
+  end as character_maximum_length,
+  case
+    when col_type like 'numeric%'
+    then nullif(
+      SPLIT_PART(REGEXP_SUBSTR(col_type, '[0-9,]+'), ',', 1),
+      '')::int
+    else null
+  end as numeric_precision,
+  case
+    when col_type like 'numeric%'
+    then nullif(
+      SPLIT_PART(REGEXP_SUBSTR(col_type, '[0-9,]+'), ',', 2),
+      '')::int
+    else null
+  end as numeric_scale
+
+from pg_get_late_binding_view_cols()
+cols(view_schema name, view_name name, col_name name,
+     col_type varchar, ordinal_position int)
+where view_name = '{{ relation.identifier }}'
+),
+
+unioned as (
+select * from bound_views
+union all
+select * from unbound_views
+)
+
+select
+*
+
+from unioned
+{% if relation.schema %}
+where table_schema = '{{ relation.schema }}'
+{% endif %}
+order by ordinal_position
+
+{% endmacro %}
+
+{% macro snowflake__get_columns_in_relation_sql(relation) %}
+{#-
+From: https://github.com/fishtown-analytics/dbt/blob/dev/louisa-may-alcott/plugins/snowflake/dbt/include/snowflake/macros/adapters.sql#L48
+Edited to include ordinal_position
+-#}
+  select
+      ordinal_position,
+      column_name,
+      data_type,
+      character_maximum_length,
+      numeric_precision,
+      numeric_scale
+
+  from
+  {{ relation.information_schema('columns') }}
+
+  where table_name ilike '{{ relation.identifier }}'
+    {% if relation.schema %}
+    and table_schema ilike '{{ relation.schema }}'
+    {% endif %}
+    {% if relation.database %}
+    and table_catalog ilike '{{ relation.database }}'
+    {% endif %}
+  order by ordinal_position
+{% endmacro %}
+
+{% macro postgres__get_columns_in_relation_sql(relation) %}
+{#-
+From: https://github.com/fishtown-analytics/dbt/blob/23484b18b71010f701b5312f920f04529ceaa6b2/plugins/postgres/dbt/include/postgres/macros/adapters.sql#L32
+Edited to include ordinal_position
+-#}
+  select
+      ordinal_position,
+      column_name,
+      data_type,
+      character_maximum_length,
+      numeric_precision,
+      numeric_scale
+
+  from {{ relation.information_schema('columns') }}
+  where table_name = '{{ relation.identifier }}'
+    {% if relation.schema %}
+    and table_schema = '{{ relation.schema }}'
+    {% endif %}
+  order by ordinal_position
+{% endmacro %}
+
+
+{% macro bigquery__get_columns_in_relation_sql(relation) %}
+
+  select
+      ordinal_position,
+      column_name,
+      data_type
+
+  from `{{ relation.database }}`.`{{ relation.schema }}`.INFORMATION_SCHEMA.COLUMNS
+  where table_name = '{{ relation.identifier }}'
+
+{% endmacro %}


### PR DESCRIPTION
To discuss:
This macro copies some SQL from dbt. In an ideal world, that SQL would be in a separate macro in dbt, so I could just call that macro to get it back. Is it worth opening an issue on dbt to pull it out into a separate macro? (IMO, probably not)

Jake also told me that in BQ you don't use the information schema to get the columns -- even though we don't run a query in dbt, is there one we can run? I tried to add one in the latest commit but couldn't get it to work -- I don't have a BQ account to test this out. (My lack of knowledge of BQ is showing here).

Similar to PR #10, lmk what you think of the testing pattern.