### PR TITLE
Add compare_column_values macro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
             cd integration_tests
             dbt deps --target postgres
             dbt seed --target postgres --full-refresh
+            dbt compile --target postgres
             dbt run --target postgres
             dbt test --target postgres
 
@@ -53,6 +54,7 @@ jobs:
             cd integration_tests
             dbt deps --target redshift
             dbt seed --target redshift --full-refresh
+            dbt compile --target redshift
             dbt run --target redshift
             dbt test --target redshift
 
@@ -64,6 +66,7 @@ jobs:
             cd integration_tests
             dbt deps --target snowflake
             dbt seed --target snowflake --full-refresh
+            dbt compile --target snowflake
             dbt run --target snowflake
             dbt test --target snowflake
 
@@ -78,6 +81,7 @@ jobs:
             cd integration_tests
             dbt deps --target bigquery
             dbt seed --target bigquery --full-refresh
+            dbt compile --target bigquery
             dbt run --target bigquery
             dbt test --target bigquery
 

--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ This macro will return a query, that, when executed, compares a column across
 two queries, and summarizes which records match perfectly for a given primary
 key:
 
-| match_status                |  count |
-| --------------------------- | ------ |
-| ✅: perfect match           | 37,721 |
-| ✅: both are null           |  5,789 |
-| 🤷: missing from b          |     25 |
-| 🤷: value is null in a only |     59 |
-| 🤷: value is null in b only |     73 |
-| 🙅: ‍values do not match     |  4,064 |
+| match_status                | count  | percent_of_total |
+|-----------------------------|--------|------------------|
+| ✅: perfect match            | 37,721 | 79.03            |
+| ✅: both are null            | 5,789  | 12.13            |
+| 🤷: missing from b          | 25     | 0.05             |
+| 🤷: value is null in a only | 59     | 0.12             |
+| 🤷: value is null in b only | 73     | 0.15             |
+| 🙅: ‍values do not match    | 4,064  | 8.51             |
 
 This macro is useful when:
 * You've used the `compare_queries` macro (above) and found that a significant
@@ -179,28 +179,29 @@ like this:
 This will give you an output like:
 ```
 Comparing column "name"
-| match_status         |  count |
-| -------------------- | ------ |
-| ✅: perfect match     | 41,573 |
-| 🤷: missing from b    |     26 |
-| 🙅: ‍values do not... |    212 |
+| match_status         | count_records | percent_of_total |
+| -------------------- | ------------- | ---------------- |
+| ✅: perfect match     |        41,573 |            99.43 |
+| 🤷: missing from b    |            26 |             0.06 |
+| 🙅: ‍values do not... |           212 |             0.51 |
 
-Comparing column "cost_per_unit"
-| match_status         |  count |
-| -------------------- | ------ |
-| ✅: perfect match     | 27,449 |
-| ✅: both are null     | 14,294 |
-| 🤷: missing from b    |     23 |
-| 🤷: exists, but nu... |      1 |
-| 🤷: exists, but nu... |     40 |
-| 🙅: ‍values do not... |      4 |
+Comparing column "msrp"
+| match_status         | count_records | percent_of_total |
+| -------------------- | ------------- | ---------------- |
+| ✅: perfect match     |        31,145 |            74.49 |
+| ✅: both are null     |        10,557 |            25.25 |
+| 🤷: missing from b    |            22 |             0.05 |
+| 🤷: value is null ... |            31 |             0.07 |
+| 🤷: value is null ... |             4 |             0.01 |
+| 🙅: ‍values do not... |            52 |             0.12 |
 
 Comparing column "status"
-| match_status         |  count |
-| -------------------- | ------ |
-| ✅: perfect match     | 37,715 |
-| 🤷: missing from b    |     26 |
-| 🙅: ‍values do not... |  4,070 |
+| match_status         | count_records | percent_of_total |
+| -------------------- | ------------- | ---------------- |
+| ✅: perfect match     |        37,715 |            90.20 |
+| 🤷: missing from b    |            26 |             0.06 |
+| 🙅: ‍values do not... |         4,070 |             9.73 |
+
 ```
 
 # To-do:

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Super similar to `compare_relations`, except it takes two select statements. Thi
 
 ## compare_column_values ([source](macros/compare_column_values.sql))
 This macro will return a query, that, when executed, compares a column across
-two queries, and summarizes which records match perfectly for a given primary
-key:
+two queries, and summarizes how many records match perfectly (note: a primary
+key is required to match values across the two queries).
 
 | match_status                | count  | percent_of_total |
 |-----------------------------|--------|------------------|

--- a/README.md
+++ b/README.md
@@ -94,13 +94,9 @@ Super similar to `compare_relations`, except it takes two select statements. Thi
 ```
 
 ## compare_column_values ([source](macros/compare_column_values.sql))
-This macro is useful when:
-* You've used the `compare_queries` macro (above) and found that a significant
-number of your records don't match.
-* So now you want to check if a particular column is problematic.
-
-This macro will return a query, that, when executed, summarizes the number of
-records that match perfectly:
+This macro will return a query, that, when executed, compares a column across
+two queries, and summarizes which records match perfectly for a given primary
+key:
 
 | match_status                |  count |
 | --------------------------- | ------ |
@@ -111,10 +107,14 @@ records that match perfectly:
 | 🤷: value is null in b only |     73 |
 | 🙅: ‍values do not match     |  4,064 |
 
+This macro is useful when:
+* You've used the `compare_queries` macro (above) and found that a significant
+number of your records don't match.
+* So now you want to find which column is causing most of these discrepancies.
+
 ### Usage:
 ```
 {# in dbt Develop #}
-
 
 {% set old_etl_relation_query %}
     select * from public.dim_product
@@ -178,11 +178,6 @@ like this:
 
 This will give you an output like:
 ```
-| match_status      |  count |
-| ----------------- | ------ |
-| ✅: perfect match  | 41,785 |
-| 🤷: missing from b |     26 |
-
 Comparing column "name"
 | match_status         |  count |
 | -------------------- | ------ |

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Super similar to `compare_relations`, except it takes two select statements. Thi
 
 ```
 
-## compare_column_values
+## compare_column_values ([source](macros/compare_column_values.sql))
 This macro is useful when:
 * You've used the `compare_queries` macro (above) and found that a significant
 number of your records don't match.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,20 @@ This macro is useful when:
 * You've used the `compare_queries` macro (above) and found that a significant
 number of your records don't match.
 * So now you want to check if a particular column is problematic.
+
+This macro will return a query, that, when executed, summarizes the number of
+records that match perfectly:
+
+| match_status                |  count |
+| --------------------------- | ------ |
+| ✅: perfect match           | 37,721 |
+| ✅: both are null           |  5,789 |
+| 🤷: missing from b          |     25 |
+| 🤷: value is null in a only |     59 |
+| 🤷: value is null in b only |     73 |
+| 🙅: ‍values do not match     |  4,064 |
+
+### Usage:
 ```
 {# in dbt Develop #}
 
@@ -122,22 +136,13 @@ number of your records don't match.
 
 {% do audit_results.print_table() %}
 ```
-This will give you an output like:
-```
-Comparing column "status"
-| match_status            |  count |
-| ----------------------- | ------ |
-| ✅: perfect match       | 37,721 |
-| 🤷: missing from b      |     25 |
-| 🙅: ‍values do not match |  4,064 |
-```
 
-Usage notes:
+**Usage notes:**
 * `primary_key` must be a unique key in both tables, otherwise the join won't
 work as expected.
 
 
-### Advanced usage
+### Advanced usage:
 Got a wide table, and want to iterate through all the columns? Try something
 like this:
 ```

--- a/integration_tests/analysis/compare_column_values_smoke_test.sql
+++ b/integration_tests/analysis/compare_column_values_smoke_test.sql
@@ -1,0 +1,20 @@
+{% set a_query %}
+    select * from {{ ref('data_compare_relations__a_relation') }}
+{% endset %}
+
+{% set audit_query = audit_helper.compare_column_values(
+    a_query=a_query,
+    b_query=a_query,
+    primary_key="col_a",
+    column_to_compare="col_b"
+) %}
+
+{{ audit_query }}
+
+{% if execute %}
+
+{% set audit_results = run_query(audit_query) %}
+
+{% do audit_results.print_table() %}
+
+{% endif %}

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -36,14 +36,24 @@ joined as (
     from a_query
 
     full outer join b_query on a_query.{{ primary_key }} = b_query.{{ primary_key }}
+),
+
+aggregated as (
+    select
+        match_status,
+        match_order,
+        count(*) as count_records
+    from joined
+
+    group by match_status, match_order
 )
 
 select
     match_status,
-    count(*) as count_records
-from joined
+    count_records,
+    round(100.0 * count_records / sum(count_records) over (), 2) as percent_of_total
 
-group by match_status, match_order
+from aggregated
 
 order by match_order
 

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -40,7 +40,7 @@ joined as (
 
 select
     match_status,
-    count(*)
+    count(*) as count_records
 from joined
 
 group by match_status, match_order

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -1,0 +1,50 @@
+{% macro compare_column_values(a_query, b_query, primary_key, column_to_compare) %}
+with a_query as (
+    {{ a_query }}
+),
+
+b_query as (
+    {{ b_query }}
+),
+
+joined as (
+    select
+        coalesce(a_query.{{ primary_key }}, b_query.{{ primary_key }}) as {{ primary_key }},
+        a_query.{{ column_to_compare }} as a_query_value,
+        b_query.{{ column_to_compare }} as b_query_value,
+        case
+            when a_query_value = b_query_value then '✅: perfect match'
+            when a_query_value is null and b_query_value is null then '✅: both are null'
+            when a_query.{{ primary_key }} is null then '🤷: ‍missing from a'
+            when b_query.{{ primary_key }} is null then '🤷: missing from b'
+            when a_query_value is null then '🤷: exists, but null in a'
+            when b_query_value is null then '🤷: exists, but null in b'
+            when a_query_value != b_query_value then '🙅: ‍values do not match'
+            else 'unknown' -- this should never happen
+        end as match_status,
+        case
+            when a_query_value = b_query_value then 0
+            when a_query_value is null and b_query_value is null then 1
+            when a_query.{{ primary_key }} is null then 2
+            when b_query.{{ primary_key }} is null then 3
+            when a_query_value is null then 4
+            when b_query_value is null then 5
+            when a_query_value != b_query_value then 6
+            else 7 -- this should never happen
+        end as match_order
+
+    from a_query
+
+    full outer join b_query on a_query.{{ primary_key }} = b_query.{{ primary_key }}
+)
+
+select
+    match_status,
+    count(*)
+from joined
+
+group by match_status, match_order
+
+order by match_order
+
+{% endmacro %}

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -13,23 +13,23 @@ joined as (
         a_query.{{ column_to_compare }} as a_query_value,
         b_query.{{ column_to_compare }} as b_query_value,
         case
-            when a_query_value = b_query_value then '✅: perfect match'
-            when a_query_value is null and b_query_value is null then '✅: both are null'
+            when a_query.{{ column_to_compare }} = b_query.{{ column_to_compare }} then '✅: perfect match'
+            when a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null then '✅: both are null'
             when a_query.{{ primary_key }} is null then '🤷: ‍missing from a'
             when b_query.{{ primary_key }} is null then '🤷: missing from b'
-            when a_query_value is null then '🤷: exists, but null in a'
-            when b_query_value is null then '🤷: exists, but null in b'
-            when a_query_value != b_query_value then '🙅: ‍values do not match'
+            when a_query.{{ column_to_compare }} is null then '🤷: exists, but null in a'
+            when b_query.{{ column_to_compare }} is null then '🤷: exists, but null in b'
+            when a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} then '🙅: ‍values do not match'
             else 'unknown' -- this should never happen
         end as match_status,
         case
-            when a_query_value = b_query_value then 0
-            when a_query_value is null and b_query_value is null then 1
+            when a_query.{{ column_to_compare }} = b_query.{{ column_to_compare }} then 0
+            when a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null then 1
             when a_query.{{ primary_key }} is null then 2
             when b_query.{{ primary_key }} is null then 3
-            when a_query_value is null then 4
-            when b_query_value is null then 5
-            when a_query_value != b_query_value then 6
+            when a_query.{{ column_to_compare }} is null then 4
+            when b_query.{{ column_to_compare }} is null then 5
+            when a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} then 6
             else 7 -- this should never happen
         end as match_order
 

--- a/macros/compare_column_values.sql
+++ b/macros/compare_column_values.sql
@@ -17,8 +17,8 @@ joined as (
             when a_query.{{ column_to_compare }} is null and b_query.{{ column_to_compare }} is null then '✅: both are null'
             when a_query.{{ primary_key }} is null then '🤷: ‍missing from a'
             when b_query.{{ primary_key }} is null then '🤷: missing from b'
-            when a_query.{{ column_to_compare }} is null then '🤷: exists, but null in a'
-            when b_query.{{ column_to_compare }} is null then '🤷: exists, but null in b'
+            when a_query.{{ column_to_compare }} is null then '🤷: value is null in a only'
+            when b_query.{{ column_to_compare }} is null then '🤷: value is null in b only'
             when a_query.{{ column_to_compare }} != b_query.{{ column_to_compare }} then '🙅: ‍values do not match'
             else 'unknown' -- this should never happen
         end as match_status,


### PR DESCRIPTION
Used this today on client work, so packaged it up as a macro.

LMK:
* What do you think of the testing pattern? Should I instead put it in a model and materialize the results of the query in a table?
* Is the % of total useful, or overkill?
* I also thought about abstracting the "advanced usage" section into its own macro, but that felt like it was probably going too far! Here's the macro if you're interested:
```
{% macro compare_all_column_values(a_query, b_query, primary_key) %}

{% if execute %}
    {% set columns_to_compare=get_columns_in_query(a_query) %}

    {% for column in columns_to_compare %}
        {{ log('Comparing column "' ~ column ~'"', info=True) }}

        {% set audit_query = audit_helper.compare_column_values(
            a_query=old_etl_relation_query,
            b_query=new_etl_relation_query,
            primary_key="product_id",
            column_to_compare=column
        ) %}

        {% set audit_results = run_query(audit_query) %}
        {% do audit_results.print_table() %}
        {{ log("", info=True) }}

    {% endfor %}
{% endif %}

{% endmacro %}
```