### PR TITLE
Update utils range

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.1.24", "<0.3.0"]
+    version: [">=0.1.24", "<0.4.0"]


### PR DESCRIPTION
The breaking changes in the macros shouldn't affect this package. I'm going to keep the range loose here, and also _not_ bump the `require-dbt-version` since someone could conceivably use a lower dbt-utils and a lower dbt version