### PR TITLE
Add columns for ordinal position/data type matches

### DIFF
--- a/macros/compare_relation_columns.sql
+++ b/macros/compare_relation_columns.sql
@@ -12,7 +12,9 @@ select
     a_cols.ordinal_position as a_ordinal_position,
     b_cols.ordinal_position as b_ordinal_position,
     a_cols.data_type as a_data_type,
-    b_cols.data_type as b_data_type
+    b_cols.data_type as b_data_type,
+    coalesce(a_cols.ordinal_position = b_cols.ordinal_position, false) as has_ordinal_position_match,
+    coalesce(a_cols.data_type = b_cols.data_type, false) as has_data_type_match
 from a_cols
 full outer join b_cols using (column_name)
 order by a_ordinal_position, b_ordinal_position


### PR DESCRIPTION
Opening instead of #19 

From @joellabes:
> While using this yesterday on a big table, I wanted an easy way to filter out the majority of identical columns to just see the outliers.
> 
> The usage I had in mind would be to wrap the whole macro in brackets and then select from the results, to avoid clashes with the order by statement etc, but could also be talked into another argument on the macro to only show inconsistent columns?