### PR TITLE
Coalesce Ordinal Positions in ORDER BY of compare_relation_columns result.

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,3 +8,6 @@ target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
+
+seeds:
+  +quote_columns: true

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -8,6 +8,3 @@ target-path: "target"
 clean-targets: ["target", "dbt_modules"]
 macro-paths: ["macros"]
 log-path: "logs"
-
-seeds:
-  +quote_columns: true

--- a/macros/compare_relation_columns.sql
+++ b/macros/compare_relation_columns.sql
@@ -17,7 +17,7 @@ select
     coalesce(a_cols.data_type = b_cols.data_type, false) as has_data_type_match
 from a_cols
 full outer join b_cols using (column_name)
-order by a_ordinal_position, b_ordinal_position
+order by COALESCE(a_ordinal_position, b_ordinal_position)
 
 {% endmacro %}
 

--- a/macros/compare_relation_columns.sql
+++ b/macros/compare_relation_columns.sql
@@ -17,7 +17,7 @@ select
     coalesce(a_cols.data_type = b_cols.data_type, false) as has_data_type_match
 from a_cols
 full outer join b_cols using (column_name)
-order by COALESCE(a_ordinal_position, b_ordinal_position)
+order by coalesce(a_ordinal_position, b_ordinal_position)
 
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation

This is a simple, quality-of-life focused change.

When running `compare_relation_columns` on two relations that differ in column naming (but not necessarily column ordering), it's useful to see the differing names listed close together. Currently, the listings are disjoint due to null sorting patterns.

## Example

Say we have two very similar table relations, `A` and `B`, which differ only by the naming of their y-ish column.

`A` has the structure:

| column | type |
| --- | --- |
| ... | ... |
| x | STRING |
| y | STRING |
| z | STRING |


While `B` has the structure:

| column | type |
| --- | --- |
| ... | ... |
| x | STRING |
| **y2** | **STRING** |
| z | STRING |

### Status Quo `compare_relation_columns`

Result: 

| column_name | a_ordinal_position | b_ordinal_position | a_data_type | b_data_type | has_ordinal_position_match | has_data_type_match |
| --- | --- | --- | --- | --- | --- | --- |
| y2 |   | 25 | STRING | STRING | False | False |
| ... lots | ... of | ... rows | ... | ... | ... | ... |
| x | 24 | 24 | STRING | STRING | True  | True  |
| y | 25 |    | STRING | STRING | False | False |
| z | 26 | 26 | STRING | STRING | True  | True  |


### This PR `compare_relation_columns`

Result: 

| column_name | a_ordinal_position | b_ordinal_position | a_data_type | b_data_type | has_ordinal_position_match | has_data_type_match |
| --- | --- | --- | --- | --- | --- | --- |
| ... lots | ... of | ... rows | ... | ... | ... | ... |
| x | 24 | 24 | STRING | STRING | True  | True  |
| y | 25 |   | STRING | STRING | False | False |
| y2 |   | 25 | STRING | STRING | False | False |
| z | 26 | 26 | STRING | STRING | True  | True  |


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
