### PR TITLE
Fix integration tests for real

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.3-stretch
+      - image: circleci/python:3.6.13-stretch
       - image: circleci/postgres:9.6.5-alpine-ram
 
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,11 @@ jobs:
           command: |
             . venv/bin/activate
             cd integration_tests
-            dbt  deps --target postgres
-            dbt  seed --target postgres --full-refresh
-            dbt  compile --target postgres
-            dbt  run --target postgres
-            dbt  test --target postgres
+            dbt --warn-error deps --target postgres
+            dbt --warn-error seed --target postgres --full-refresh
+            dbt --warn-error compile --target postgres
+            dbt --warn-error run --target postgres
+            dbt --warn-error test --target postgres
 
       - run:
           name: "Run Tests - Redshift"
@@ -53,11 +53,11 @@ jobs:
             . venv/bin/activate
             echo `pwd`
             cd integration_tests
-            dbt  deps --target redshift
-            dbt  seed --target redshift --full-refresh
-            dbt  compile --target redshift
-            dbt  run --target redshift
-            dbt  test --target redshift
+            dbt --warn-error deps --target redshift
+            dbt --warn-error seed --target redshift --full-refresh
+            dbt --warn-error compile --target redshift
+            dbt --warn-error run --target redshift
+            dbt --warn-error test --target redshift
 
       - run:
           name: "Run Tests - Snowflake"
@@ -65,11 +65,11 @@ jobs:
             . venv/bin/activate
             echo `pwd`
             cd integration_tests
-            dbt  deps --target snowflake
-            dbt  seed --target snowflake --full-refresh
-            dbt  compile --target snowflake
-            dbt  run --target snowflake
-            dbt  test --target snowflake
+            dbt --warn-error deps --target snowflake
+            dbt --warn-error seed --target snowflake --full-refresh
+            dbt --warn-error compile --target snowflake
+            dbt --warn-error run --target snowflake
+            dbt --warn-error test --target snowflake
 
       - run:
           name: "Run Tests - BigQuery"
@@ -80,11 +80,11 @@ jobs:
             . venv/bin/activate
             echo `pwd`
             cd integration_tests
-            dbt  deps --target bigquery
-            dbt  seed --target bigquery --full-refresh
-            dbt  compile --target bigquery
-            dbt  run --target bigquery
-            dbt  test --target bigquery
+            dbt --warn-error deps --target bigquery
+            dbt --warn-error seed --target bigquery --full-refresh
+            dbt --warn-error compile --target bigquery
+            dbt --warn-error run --target bigquery
+            dbt --warn-error test --target bigquery
 
 
       - save_cache:


### PR DESCRIPTION
This was a bug in dbt v0.19.1 + olde versions of py36! That explains why I couldn't replicate it locally. Simple fix here is to upgrade to a newer version of python 3.6. (We could use an even newer version of python, too.)

- Revert #31 (in the sense of re-adding `--warn-error`)
- Upgrade py36 in CircleCI to 3.6.13

## Checklist
- ~I have verified that these changes work locally~
- ~I have updated the README.md (if applicable)~
- [x] I have added tests & descriptions to my models (and macros if applicable)
