### PR TITLE
Use specific column references in order by

### DIFF
--- a/macros/compare_relation_columns.sql
+++ b/macros/compare_relation_columns.sql
@@ -17,7 +17,7 @@ select
     coalesce(a_cols.data_type = b_cols.data_type, false) as has_data_type_match
 from a_cols
 full outer join b_cols using (column_name)
-order by coalesce(a_ordinal_position, b_ordinal_position)
+order by coalesce(a_cols.ordinal_position, b_cols.ordinal_position)
 
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation
I merged #29 without passing tests, because it changed this line:
```
order by a_ordinal_position, b_ordinal_position
```
to this:
```
order by coalesce(a_ordinal_position, b_ordinal_position)
```
and, like, that should pass, right?

narrator: [it did not pass](https://app.circleci.com/pipelines/github/fishtown-analytics/dbt-audit-helper/110/workflows/616f510a-b274-4b4b-91f5-7604ec54a1af/jobs/102)
```
  Database Error in analysis compare_relation_columns_smoke_test (analysis/compare_relation_columns_smoke_test.sql)
    column "a_ordinal_position" does not exist
    LINE 58: order by coalesce(a_ordinal_position, b_ordinal_position)
```
So, TIL that postgres can use lateral column aliases in an `order by`, but not wrap them in a `coalesce` function. weird.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
