### PR TITLE
Add adapter.dispatch to compare_and_classify_query_results

### DIFF
--- a/macros/compare_and_classify_query_results.sql
+++ b/macros/compare_and_classify_query_results.sql
@@ -1,5 +1,9 @@
 {% macro compare_and_classify_query_results(a_query, b_query, primary_key_columns=[], columns=[], event_time=None, sample_limit=20) %}
-    
+    {{ return(adapter.dispatch('compare_and_classify_query_results', 'audit_helper')(a_query, b_query, primary_key_columns, columns, event_time, sample_limit)) }}
+{% endmacro %}
+
+{% macro default__compare_and_classify_query_results(a_query, b_query, primary_key_columns, columns, event_time, sample_limit) %}
+
     {% set columns = audit_helper._ensure_all_pks_are_in_column_set(primary_key_columns, columns) %}
     {% set joined_cols = columns | join(", ") %}
 


### PR DESCRIPTION
## Summary

- Wraps `compare_and_classify_query_results` with `adapter.dispatch()`, matching the pattern used by all other public macros in this package
- Enables adapters to provide dialect-specific overrides (e.g. for T-SQL which has no boolean column type)
- Also fixes `compare_and_classify_relation_rows` since it delegates to this macro

Closes #131

## Context

`compare_and_classify_query_results` was the only public macro in dbt-audit-helper **not** using `adapter.dispatch()`. The macro uses `true`/`false` literals directly, which causes syntax errors on T-SQL adapters (Microsoft Fabric, SQL Server, Azure SQL) that have no boolean column type. Since the macro wasn't dispatched, there was no way to provide a `fabric__compare_and_classify_query_results` override.

## Changes

The existing implementation is moved from `compare_and_classify_query_results` to `default__compare_and_classify_query_results`, and the public macro now dispatches via `adapter.dispatch('compare_and_classify_query_results', 'audit_helper')`. No functional change for existing users — the default implementation is identical.

## Test plan

- [ ] Existing integration tests pass (no behavioral change for the default implementation)
- [ ] Verified the dispatch pattern matches `compare_all_columns`, `compare_column_values`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)