### PR TITLE
Fix argument-passing bugs in event_time comparison bounds

### DIFF
--- a/macros/compare_which_query_columns_differ.sql
+++ b/macros/compare_which_query_columns_differ.sql
@@ -5,7 +5,7 @@
 {% macro default__compare_which_query_columns_differ(a_query, b_query, primary_key_columns, columns, event_time) %}
     {% set columns = audit_helper._ensure_all_pks_are_in_column_set(primary_key_columns, columns) %}
     {% if event_time %}
-        {% set event_time_props = audit_helper._get_comparison_bounds(event_time) %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(a_query, b_query, event_time) %}
     {% endif %}
 
     {% set joined_cols = columns | join (", ") %}

--- a/macros/quick_are_queries_identical.sql
+++ b/macros/quick_are_queries_identical.sql
@@ -22,7 +22,7 @@ but it's a good way to quickly verify identical results if that's what you're ex
 {% macro bigquery__quick_are_queries_identical(query_a, query_b, columns, event_time) %}
     {% set joined_cols = columns | join(", ") %}
     {% if event_time %}
-        {% set event_time_props = audit_helper._get_comparison_bounds(a_query, b_query, event_time) %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(query_a, query_b, event_time) %}
     {% endif %}
 
     with query_a as (
@@ -51,7 +51,7 @@ but it's a good way to quickly verify identical results if that's what you're ex
 {% macro snowflake__quick_are_queries_identical(query_a, query_b, columns, event_time) %}
     {% set joined_cols = columns | join(", ") %}
     {% if event_time %}
-        {% set event_time_props = audit_helper._get_comparison_bounds(a_query, b_query, event_time) %}
+        {% set event_time_props = audit_helper._get_comparison_bounds(query_a, query_b, event_time) %}
     {% endif %}
 
     select count(distinct hash_result) = 1 as are_tables_identical


### PR DESCRIPTION
## Summary

Fixes two argument-passing bugs that cause crashes when `event_time` is used:

- **`compare_which_query_columns_differ`**: The call to `_get_comparison_bounds` on line 8 only passed `event_time` (1 arg) instead of the required `a_query, b_query, event_time` (3 args)
- **`quick_are_queries_identical`** (BigQuery + Snowflake dispatches): Referenced undefined variables `a_query`/`b_query` instead of the actual parameter names `query_a`/`query_b`

## Test plan

- [ ] Run `compare_which_query_columns_differ` with a non-null `event_time` argument
- [ ] Run `quick_are_queries_identical` with a non-null `event_time` on BigQuery
- [ ] Run `quick_are_queries_identical` with a non-null `event_time` on Snowflake

Fixes #134, fixes #135